### PR TITLE
feat(rabbit): support multiple configs on the same handler

### DIFF
--- a/packages/rabbitmq/src/rabbitmq.interfaces.ts
+++ b/packages/rabbitmq/src/rabbitmq.interfaces.ts
@@ -97,7 +97,10 @@ export interface ConnectionInitOptions {
 }
 
 export type RabbitMQChannels = Record<string, RabbitMQChannelConfig>;
-export type RabbitMQHandlers = Record<string, MessageHandlerOptions>;
+export type RabbitMQHandlers = Record<
+  string,
+  MessageHandlerOptions | MessageHandlerOptions[]
+>;
 
 export interface RabbitMQConfig {
   name?: string;


### PR DESCRIPTION
Support multiple configurations on the same handler to support use cases where users want to reuse the same handler method across multiple queues. For example, this could be useful for a situation where messages are partitioned across multiple queues by a consistent hash exchange.

fix #624